### PR TITLE
Make the 'global_chapters_dir' only if 'global_chapters' is true

### DIFF
--- a/chapter-make-read.lua
+++ b/chapter-make-read.lua
@@ -122,7 +122,7 @@ end
 
 --create global_chapters_dir if it doesn't exist
 global_chapters_dir = mp.command_native({ "expand-path", o.global_chapters_dir })
-if utils.readdir(global_chapters_dir) == nil then
+if o.global_chapters and utils.readdir(global_chapters_dir) == nil then
     local is_windows = package.config:sub(1, 1) == "\\"
     local windows_args = { 'powershell', '-NoProfile', '-Command', 'mkdir', string.format("\"%s\"", global_chapters_dir) }
     local unix_args = { 'mkdir', '-p', global_chapters_dir }


### PR DESCRIPTION
Hi dyphire, I keep `global_chapters` set to `false` and I didn't want the script to make the `global_chapters_dir`, so I made this change. Merge it if you like it.